### PR TITLE
[#4, #5] react-hook-form 도입, 에러 발생 시 catch로 넘어가지 않는 현상 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-helmet": "^6.1.0",
+				"react-hook-form": "^7.41.5",
 				"react-icons": "^4.4.0",
 				"react-intersection-observer": "^9.4.0",
 				"react-router-dom": "^6.3.0",
@@ -15123,6 +15124,21 @@
 				"react": ">=16.3.0"
 			}
 		},
+		"node_modules/react-hook-form": {
+			"version": "7.41.5",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+			"integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
+			"engines": {
+				"node": ">=12.22.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/react-hook-form"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17 || ^18"
+			}
+		},
 		"node_modules/react-icons": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
@@ -29078,6 +29094,12 @@
 				"react-fast-compare": "^3.1.1",
 				"react-side-effect": "^2.1.0"
 			}
+		},
+		"react-hook-form": {
+			"version": "7.41.5",
+			"resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.41.5.tgz",
+			"integrity": "sha512-DAKjSJ7X9f16oQrP3TW2/eD9N6HOgrmIahP4LOdFphEWVfGZ2LulFd6f6AQ/YS/0cx/5oc4j8a1PXxuaurWp/Q==",
+			"requires": {}
 		},
 		"react-icons": {
 			"version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-helmet": "^6.1.0",
+		"react-hook-form": "^7.41.5",
 		"react-icons": "^4.4.0",
 		"react-intersection-observer": "^9.4.0",
 		"react-router-dom": "^6.3.0",

--- a/src/components/router/index.jsx
+++ b/src/components/router/index.jsx
@@ -22,19 +22,19 @@ const MyPwManage = React.lazy(() => import('../../pages/MyPwManage'));
 const CommentInPost = React.lazy(() => import('../../pages/CommentInPost'));
 
 const privateRoutePath = [
-	{ id: 2, path: PRIVATE_ROUTE_PATH.COMMENT_IN_POST, element: <CommentInPost /> },
-	{ id: 3, path: PRIVATE_ROUTE_PATH.POSTING_VIEWER, element: <PostingViewer /> },
-	{ id: 4, path: PRIVATE_ROUTE_PATH.POSTING_SEARCH_VIEWER, element: <PostingViewer /> },
-	{ id: 5, path: PRIVATE_ROUTE_PATH.ROOM_VIEWER, element: <RoomViewer /> },
-	{ id: 6, path: PRIVATE_ROUTE_PATH.ROOM_SEARCH_VIEWER, element: <RoomViewer /> },
-	{ id: 7, path: PRIVATE_ROUTE_PATH.POSTING_DETAIL, element: <Detail /> },
-	{ id: 8, path: PRIVATE_ROUTE_PATH.MY_INFO_MANAGE, element: <MyInfoManage /> },
-	{ id: 9, path: PRIVATE_ROUTE_PATH.MY_PASS_MANAGE, element: <MyPwManage /> },
-	{ id: 10, path: PRIVATE_ROUTE_PATH.MY_PAGE, element: <Mypage /> },
-	{ id: 11, path: PRIVATE_ROUTE_PATH.POSTING, element: <Post /> },
-	{ id: 12, path: PRIVATE_ROUTE_PATH.POSTING_EDIT, element: <Post /> },
-	{ id: 13, path: PRIVATE_ROUTE_PATH.CREATE_ROOM, element: <CreateRoom /> },
-	{ id: 14, path: PRIVATE_ROUTE_PATH.ROOM_DETAIL, element: <ChatRoom /> }
+	{ id: 1, path: PRIVATE_ROUTE_PATH.COMMENT_IN_POST, element: <CommentInPost /> },
+	{ id: 2, path: PRIVATE_ROUTE_PATH.POSTING_VIEWER, element: <PostingViewer /> },
+	{ id: 3, path: PRIVATE_ROUTE_PATH.POSTING_SEARCH_VIEWER, element: <PostingViewer /> },
+	{ id: 4, path: PRIVATE_ROUTE_PATH.ROOM_VIEWER, element: <RoomViewer /> },
+	{ id: 5, path: PRIVATE_ROUTE_PATH.ROOM_SEARCH_VIEWER, element: <RoomViewer /> },
+	{ id: 6, path: PRIVATE_ROUTE_PATH.POSTING_DETAIL, element: <Detail /> },
+	{ id: 7, path: PRIVATE_ROUTE_PATH.MY_INFO_MANAGE, element: <MyInfoManage /> },
+	{ id: 8, path: PRIVATE_ROUTE_PATH.MY_PASS_MANAGE, element: <MyPwManage /> },
+	{ id: 9, path: PRIVATE_ROUTE_PATH.MY_PAGE, element: <Mypage /> },
+	{ id: 10, path: PRIVATE_ROUTE_PATH.POSTING, element: <Post /> },
+	{ id: 11, path: PRIVATE_ROUTE_PATH.POSTING_EDIT, element: <Post /> },
+	{ id: 12, path: PRIVATE_ROUTE_PATH.CREATE_ROOM, element: <CreateRoom /> },
+	{ id: 13, path: PRIVATE_ROUTE_PATH.ROOM_DETAIL, element: <ChatRoom /> }
 ];
 
 const authRoutePath = [

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -21,7 +21,7 @@ const Login = () => {
 
 	const onSubmitLogin = async (data) => {
 		try {
-			const res = await instance.post('/api/login', JSON.stringify(data));
+			const res = await instance.post('/api/login', data);
 			const token = res.headers.authorization;
 			const refreshtoken = res.headers.refreshtoken;
 			const { username, nickname, user_type, kakao } = res.data;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -32,7 +32,7 @@ const Login = () => {
 			alert('환영합니다!');
 			navigate('/viewer/posting/list');
 		} catch (err) {
-			alert('아이디 또는 패스워드를 확인해주세요!');
+			alert(err.response.data);
 		}
 	};
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useRef } from 'react';
 import styled from 'styled-components';
 import instance from '../shared/axios';
 import kakao_login from '../assets/images/kakao_login.png';
@@ -8,8 +8,8 @@ import { userContext } from '../context/UserProvider';
 import { Helmet } from 'react-helmet';
 
 const Login = () => {
-	const email_ref = React.useRef(null);
-	const pw_ref = React.useRef(null);
+	const email_ref = useRef(null);
+	const pw_ref = useRef(null);
 
 	const navigate = useNavigate();
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -48,6 +48,12 @@ const Login = () => {
 
 	return (
 		<LoginWrapper>
+			<Helmet>
+				<title>IT-ing</title>
+				<link rel="apple-touch-icon" sizes="180x180" href="180.ico" />
+				<link rel="icon" type="image/png" sizes="32x32" href="32.ico" />
+				<link rel="icon" type="image/png" sizes="16x16" href="16.ico" />
+			</Helmet>
 			<Logo onClick={() => navigate('/viewer/posting/list')}>
 				<svg width="99" height="57" viewBox="0 0 99 57" fill="none" xmlns="http://www.w3.org/2000/svg">
 					<g clipPath="url(#clip0_833_4252)">
@@ -79,13 +85,6 @@ const Login = () => {
 					</defs>
 				</svg>
 			</Logo>
-
-			<Helmet>
-				<title>IT-ing</title>
-				<link rel="apple-touch-icon" sizes="180x180" href="180.ico" />
-				<link rel="icon" type="image/png" sizes="32x32" href="32.ico" />
-				<link rel="icon" type="image/png" sizes="16x16" href="16.ico" />
-			</Helmet>
 
 			<Inputarea>
 				<input placeholder="ID" ref={email_ref} type="email" />

--- a/src/pages/MyInfoManage.jsx
+++ b/src/pages/MyInfoManage.jsx
@@ -39,15 +39,15 @@ const MyInfoManage = () => {
 
 	const myInfoChangeHandler = async (data) => {
 		try {
-			const res = await instance.put('/api/mypage/user/info', data, {
+			await instance.put('/api/mypage/user/info', data, {
 				headers: { 'Content-Type': `application/json` }
 			});
-			alert(res.data);
-			const userData = { ...userInfo, ...Object(data) };
+			alert('개인정보 변경에 성공하였습니다.');
+			const userData = { ...userInfo, ...data };
 			setUserInfo(userData);
 			navigate('/mypage');
 		} catch (err) {
-			console.log('실패', err);
+			alert('개인정보 변경에 실패하였습니다.');
 		}
 	};
 

--- a/src/pages/MyInfoManage.jsx
+++ b/src/pages/MyInfoManage.jsx
@@ -33,7 +33,7 @@ const MyInfoManage = () => {
 			alert('사용 가능한 닉네임입니다.');
 		} catch (err) {
 			setNicknameCheck(false);
-			alert('사용 불가능한 닉네임입니다.');
+			alert(err.response.data);
 		}
 	};
 
@@ -43,15 +43,15 @@ const MyInfoManage = () => {
 			return;
 		}
 		try {
-			await instance.put('/api/mypage/user/info', data, {
+			const res = await instance.put('/api/mypage/user/info', data, {
 				headers: { 'Content-Type': `application/json` }
 			});
 			const userData = { ...userInfo, ...data };
 			setUserInfo(userData);
-			alert('개인정보 변경에 성공하였습니다.');
+			alert(res.data);
 			navigate('/mypage');
 		} catch (err) {
-			alert('개인정보 변경에 실패하였습니다.');
+			alert(err.response.data);
 		}
 	};
 

--- a/src/pages/MyInfoManage.jsx
+++ b/src/pages/MyInfoManage.jsx
@@ -39,13 +39,11 @@ const MyInfoManage = () => {
 
 	const myInfoChangeHandler = async (data) => {
 		try {
-			const res = await instance.put('/api/mypage/user/info', JSON.stringify(data), {
+			const res = await instance.put('/api/mypage/user/info', data, {
 				headers: { 'Content-Type': `application/json` }
 			});
 			alert(res.data);
-			console.log(Object(data));
-			const userData = {...Object(data), ...userInfo.user};
-			console.log("userData : ", userData);
+			const userData = { ...userInfo, ...Object(data) };
 			setUserInfo(userData);
 			navigate('/mypage');
 		} catch (err) {

--- a/src/pages/MyInfoManage.jsx
+++ b/src/pages/MyInfoManage.jsx
@@ -38,6 +38,10 @@ const MyInfoManage = () => {
 	};
 
 	const myInfoChangeHandler = async (data) => {
+		if (!nicknameCheck) {
+			alert('닉네임 중복 확인을 해주세요.');
+			return;
+		}
 		try {
 			await instance.put('/api/mypage/user/info', data, {
 				headers: { 'Content-Type': `application/json` }
@@ -52,8 +56,7 @@ const MyInfoManage = () => {
 	};
 
 	useEffect(() => {
-		if (nicknameCheck) setChangeBtnState(true);
-		else if (!nicknameCheck && userTypeState) setChangeBtnState(true);
+		if (nicknameCheck || userTypeState) setChangeBtnState(true);
 		else setChangeBtnState(false);
 	}, [nicknameCheck, userTypeState]);
 

--- a/src/pages/MyInfoManage.jsx
+++ b/src/pages/MyInfoManage.jsx
@@ -42,9 +42,9 @@ const MyInfoManage = () => {
 			await instance.put('/api/mypage/user/info', data, {
 				headers: { 'Content-Type': `application/json` }
 			});
-			alert('개인정보 변경에 성공하였습니다.');
 			const userData = { ...userInfo, ...data };
 			setUserInfo(userData);
+			alert('개인정보 변경에 성공하였습니다.');
 			navigate('/mypage');
 		} catch (err) {
 			alert('개인정보 변경에 실패하였습니다.');
@@ -112,7 +112,7 @@ const MyInfoManage = () => {
 						<option value="SENIOR">시니어</option>
 					</select>
 				</UserTypeBox>
-				<ChangeMyInfoBtn onClick={myInfoChangeHandler} disabled={!changeBtnState || isSubmitting}>
+				<ChangeMyInfoBtn disabled={!changeBtnState || isSubmitting} type="submit">
 					{' '}
 					변경하기{' '}
 				</ChangeMyInfoBtn>

--- a/src/pages/MyPwManage.jsx
+++ b/src/pages/MyPwManage.jsx
@@ -33,19 +33,16 @@ const MyPwManage = () => {
 		}
 	};
 
+	const formChangeCheck = () => {
+		const { password, changePassword, confirmChangePassword } = getValues();
+		if (!password || !changePassword || !confirmChangePassword) setIsAbleSubmit(false);
+		else setIsAbleSubmit(true);
+	};
+
 	useEffect(() => {
 		if (userInfo.kakao) {
 			alert('카카오회원은 비밀번호 변경을 할 수 없습니다.');
 			return navigate('/mypage');
-		}
-	}, []);
-
-	useEffect(() => {
-		const inputValues = getValues();
-		const temp = Object.values(inputValues);
-		for (let i = 0; i < temp.length; i++) {
-			if (!temp[i]) setIsAbleSubmit(false);
-			else setIsAbleSubmit(true);
 		}
 	}, []);
 
@@ -66,10 +63,7 @@ const MyPwManage = () => {
 						autoComplete="off"
 						{...register('password', {
 							required: '현재 비밀번호 입력은 필수입니다.',
-							onChange: ({ target }) => {
-								const value = target;
-								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
-							}
+							onChange: formChangeCheck
 						})}
 					></input>
 					{errors.password && <Fail>{errors.password.message}</Fail>}
@@ -94,10 +88,7 @@ const MyPwManage = () => {
 								value: 20,
 								message: '8자리 이상, 20자리 미만으로 입력해주세요.'
 							},
-							onChange: ({ target }) => {
-								const value = target;
-								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
-							}
+							onChange: formChangeCheck
 						})}
 					></input>
 					{errors.changePassword && <Fail>{errors.changePassword.message}</Fail>}
@@ -113,10 +104,7 @@ const MyPwManage = () => {
 									return changePassword === value || '비밀번호가 일치하지 않습니다.';
 								}
 							},
-							onChange: ({ target }) => {
-								const value = target;
-								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
-							}
+							onChange: formChangeCheck
 						})}
 					></input>
 					{errors.confirmChangePassword && <Fail>{errors.confirmChangePassword.message}</Fail>}

--- a/src/pages/MyPwManage.jsx
+++ b/src/pages/MyPwManage.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useContext, useEffect } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -6,64 +6,31 @@ import { userContext } from '../context/UserProvider';
 import Header from '../components/header/Header';
 import instance from '../shared/axios';
 import { Helmet } from 'react-helmet';
+import { useForm } from 'react-hook-form';
 
 const MyPwManage = () => {
-	const _pwcheck = /^(?=.*[!@#$%^&.*])[0-9a-zA-Z!@#$%^&.*]{8,20}$/;
-	const nowPw_ref = useRef();
-	const newPw_ref = useRef(null);
-	const newConfirmPw_ref = useRef(null);
+	const {
+		register,
+		handleSubmit,
+		getValues,
+		formState: { isSubmitting, errors }
+	} = useForm({
+		mode: 'onChange'
+	});
 	const navigate = useNavigate();
 
 	const context = useContext(userContext);
 	const { userInfo } = context.state;
+	const [isAbleSubmit, setIsAbleSubmit] = useState(false);
 
-	const [changeBtnState, setChangeBtnState] = useState(false);
-
-	const [pwcheck, setPwCheck] = useState(null);
-	const [pwrecheck, setPwReCheck] = useState(null);
-
-	//비밀번호 형식이 맞지 않을 경우
-	const pwCheck = () => {
-		if (!_pwcheck.test(newPw_ref.current.value)) {
-			setPwCheck(false);
-		} else {
-			setPwCheck(true);
-		}
-	};
-
-	// 유저 비밀번호 확인 일치 체크
-	const pwReCheck = () => {
-		if (newPw_ref.current.value !== newConfirmPw_ref.current.value) {
-			setPwReCheck(false);
-		} else {
-			setPwReCheck(true);
-		}
-	};
-
-	const pwCheckHandler = () => {
-		if (
-			_pwcheck.test(nowPw_ref.current.value) &&
-			_pwcheck.test(newPw_ref.current.value) &&
-			newPw_ref.current.value.length === newConfirmPw_ref.current.value.length
-		) {
-			return setChangeBtnState(true);
-		} else {
-			return setChangeBtnState(false);
-		}
-	};
-
-	const myPwChangeHandler = async () => {
-		const data = {
-			password: nowPw_ref.current.value,
-			changePassword: newPw_ref.current.value,
-			confirmChangePassword: newConfirmPw_ref.current.value
-		};
+	const myPwChangeHandler = async (data) => {
+		console.log(data);
 		try {
-			await instance.put('/api/mypage/user/password', data);
-			alert('비밀번호를 변경하였습니다.');
+			const res = await instance.put('/api/mypage/user/password', data);
+			alert(res.data);
 			navigate('/mypage');
 		} catch (err) {
-			alert(err.response.data);
+			console.log(err.response.data);
 		}
 	};
 
@@ -71,6 +38,15 @@ const MyPwManage = () => {
 		if (userInfo.kakao) {
 			alert('카카오회원은 비밀번호 변경을 할 수 없습니다.');
 			return navigate('/mypage');
+		}
+	}, []);
+
+	useEffect(() => {
+		const inputValues = getValues();
+		const temp = Object.values(inputValues);
+		for (let i = 0; i < temp.length; i++) {
+			if (!temp[i]) setIsAbleSubmit(false);
+			else setIsAbleSubmit(true);
 		}
 	}, []);
 
@@ -83,53 +59,72 @@ const MyPwManage = () => {
 				<link rel="icon" type="image/png" sizes="16x16" href="16.ico" />
 			</Helmet>
 			<Header title="비밀번호 변경" isAction={true} />
-			<MyPwWrapper>
+			<MyPwWrapper onSubmit={handleSubmit(myPwChangeHandler)}>
 				<NowPwBox>
 					<p>현재 비밀번호</p>
-					<input ref={nowPw_ref} type="password" onChange={pwCheckHandler} autoComplete="off"></input>
+					<input
+						type="password"
+						autoComplete="off"
+						{...register('password', {
+							required: '현재 비밀번호 입력은 필수입니다.',
+							onChange: ({ target }) => {
+								const value = target;
+								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
+							}
+						})}
+					></input>
+					{errors.password && <Fail>{errors.password.message}</Fail>}
 				</NowPwBox>
 				<NewPwBox>
 					<p>신규 비밀번호</p>
 					<input
-						ref={newPw_ref}
 						type="password"
 						placeholder="영문이나 숫자, 특수문자(!@#$%^&.*)포함 8~20자"
-						onChange={pwCheckHandler}
 						autoComplete="off"
-						onBlur={pwCheck}
+						{...register('changePassword', {
+							required: '변경할 비밀번호를 입력해주세요.',
+							pattern: {
+								value: /(?=.*[!@#$%^&.*])[0-9a-zA-Z!@#$%^&.*]$/,
+								message: '영문이나 숫자, 특수문자(!@#$%^&.*)를 포함해주세요.'
+							},
+							minLength: {
+								value: 8,
+								message: '8자리 이상, 20자리 미만으로 입력해주세요.'
+							},
+							maxLength: {
+								value: 20,
+								message: '8자리 이상, 20자리 미만으로 입력해주세요.'
+							},
+							onChange: ({ target }) => {
+								const value = target;
+								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
+							}
+						})}
 					></input>
-					{pwcheck === null ? (
-						<None />
-					) : pwcheck ? (
-						<None />
-					) : (
-						<Fail>
-							<p>특수문자를 포함 영문/숫자(8-20자)으로 작성해주세요!</p>
-						</Fail>
-					)}
+					{errors.changePassword && <Fail>{errors.changePassword.message}</Fail>}
 					<input
-						ref={newConfirmPw_ref}
 						type="password"
 						placeholder="비밀번호 확인"
-						onChange={pwCheckHandler}
 						autoComplete="off"
-						onBlur={pwReCheck}
+						{...register('confirmChangePassword', {
+							required: '비밀번호가 일치하지 않습니다.',
+							validate: {
+								matchesPreviousPassword: (value) => {
+									const { changePassword } = getValues();
+									return changePassword === value || '비밀번호가 일치하지 않습니다.';
+								}
+							},
+							onChange: ({ target }) => {
+								const value = target;
+								!value ? setIsAbleSubmit(false) : setIsAbleSubmit(true);
+							}
+						})}
 					></input>
-					{pwrecheck === null ? (
-						<None />
-					) : pwrecheck ? (
-						<None />
-					) : (
-						<Fail>
-							<p>입력하신 비밀번호와 다릅니다!</p>
-						</Fail>
-					)}
+					{errors.confirmChangePassword && <Fail>{errors.confirmChangePassword.message}</Fail>}
 				</NewPwBox>
 				<ChangeMyPwBtn
-					onClick={() => {
-						myPwChangeHandler();
-					}}
-					disabled={!changeBtnState}
+					disabled={isSubmitting || errors.password || errors.changePassword || errors.confirmChangePassword || !isAbleSubmit}
+					type="submit"
 				>
 					변경하기
 				</ChangeMyPwBtn>
@@ -140,7 +135,7 @@ const MyPwManage = () => {
 
 export default MyPwManage;
 
-const MyPwWrapper = styled.div`
+const MyPwWrapper = styled.form`
 	margin-top: 60px;
 	background: white;
 	width: 100%;
@@ -207,16 +202,9 @@ const ChangeMyPwBtn = styled.button`
 	border: none;
 `;
 
-const None = styled.div`
-	display: none;
-`;
-
 const Fail = styled.div`
-	p {
-		margin-top: 2px;
-		font-size: 13px;
-		// padding-bottom : 15px;
-		padding-left: 10px;
-		color: red;
-	}
+	margin-top: 2px;
+	font-size: 13px;
+	padding-left: 10px;
+	color: red;
 `;

--- a/src/pages/MyPwManage.jsx
+++ b/src/pages/MyPwManage.jsx
@@ -24,13 +24,12 @@ const MyPwManage = () => {
 	const [isAbleSubmit, setIsAbleSubmit] = useState(false);
 
 	const myPwChangeHandler = async (data) => {
-		console.log(data);
 		try {
 			const res = await instance.put('/api/mypage/user/password', data);
 			alert(res.data);
 			navigate('/mypage');
 		} catch (err) {
-			console.log(err.response.data);
+			alert(err.response.data);
 		}
 	};
 

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -55,8 +55,9 @@ const Signup = () => {
 			alert('닉네임 확인이 필요해요!');
 			return;
 		}
+		console.log(data);
 		try {
-			await instance.post('/api/signup', JSON.stringify(data), {
+			await instance.post('/api/signup', data, {
 				headers: { 'Content-Type': `application/json` }
 			});
 			alert('회원가입이 완료되었습니다!');

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -29,7 +29,7 @@ const Signup = () => {
 			alert('사용 가능한 ID 입니다!');
 			setIdDuple(true);
 		} catch (err) {
-			alert('이미 사용된 ID 입니다!');
+			alert(err.response.data);
 			setIdDuple(false);
 		}
 	};
@@ -42,7 +42,7 @@ const Signup = () => {
 			alert('사용 가능한 닉네임 입니다!');
 			setNickNameDuple(true);
 		} catch (err) {
-			alert('이미 사용된 닉네임 입니다!');
+			alert(err.response.data);
 			setNickNameDuple(false);
 		}
 	};
@@ -55,7 +55,6 @@ const Signup = () => {
 			alert('닉네임 확인이 필요해요!');
 			return;
 		}
-		console.log(data);
 		try {
 			await instance.post('/api/signup', data, {
 				headers: { 'Content-Type': `application/json` }

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,159 +1,68 @@
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import instance from '../shared/axios';
 import { Link, useNavigate } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import { useForm } from 'react-hook-form';
 
 const Signup = () => {
 	const navigate = useNavigate();
-
-	//ref로 input값 받아오기
-	const email_ref = useRef(null);
-	const nickname_ref = useRef(null);
-	const pw_ref = useRef(null);
-	const pwcheck_ref = useRef(null);
-
-	//input값 제한 조건 충족에 따른 p태그 반환
-	const [emailcheck, setEmailCheck] = useState(null);
-	const [nicknamecheck, setNickNameCheck] = useState(null);
-	const [pwcheck, setPwCheck] = useState(null);
-	const [pwrecheck, setPwReCheck] = useState(null);
+	const {
+		register,
+		handleSubmit,
+		getValues,
+		formState: { isSubmitting, errors }
+	} = useForm({ mode: 'onChange' });
 	const [userType, setUserType] = useState('SEEKER');
-
-	//중복확인 여부
 	const [idduple, setIdDuple] = useState(null);
 	const [nicknameduple, setNickNameDuple] = useState(null);
-
-	//아이디(이메일) 제한 조건 : 이메일 형식
-	const email_limit = (email) => {
-		let _reg = /^[a-zA-Z0-9+-_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
-		return _reg.test(email);
-	};
-
-	//아이디 형식이 맞지 않을 경우
-	const idCheck = () => {
-		if (!email_limit(email_ref.current.value)) {
-			setEmailCheck(false);
-		} else {
-			setEmailCheck(true);
-		}
-	};
-
-	// 닉네임 제한 조건 : 2자리 이상 10자리 이하 한글/영문/숫자
-	const nickname_limit = (nickname) => {
-		let _reg = /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{2,10}$/;
-		return _reg.test(nickname);
-	};
-
-	//닉네임 형식이 맞지 않을 경우
-	const nickNameCheck = () => {
-		if (!nickname_limit(nickname_ref.current.value)) {
-			setNickNameCheck(false);
-		} else {
-			setNickNameCheck(true);
-		}
-	};
-
-	// 비밀번호 제한 조건 : 8자리 이상 20자리 이하
-	const password_limit = (password) => {
-		let _reg = /^(?=.*[@$!%*?&])[0-9a-zA-Z!@#$%^&.*]{8,20}$/;
-		return _reg.test(password);
-	};
-
-	//비밀번호 형식이 맞지 않을 경우
-	const pwCheck = () => {
-		if (!password_limit(pw_ref.current.value)) {
-			setPwCheck(false);
-		} else {
-			setPwCheck(true);
-		}
-	};
-
-	// 유저 비밀번호 확인 일치 체크
-	const pwReCheck = () => {
-		if (pw_ref.current.value !== pwcheck_ref.current.value) {
-			setPwReCheck(false);
-		} else {
-			setPwReCheck(true);
-		}
-	};
-
-	// 유저 타입 가져오기
 	const selectUserType = (e) => {
 		setUserType(e.target.value);
+		console.log(userType);
 	};
 
-	const submitId = async () => {
-		if (emailcheck === null) {
-			alert('ID를 입력해주세요!');
-		} else if (emailcheck === false) {
-			alert('ID 형식을 확인해주세요!');
-		} else {
-			try {
-				await instance.get(`/api/users/email/${email_ref.current.value}`);
-				alert('사용 가능한 ID 입니다!');
-				setIdDuple(true);
-			} catch (err) {
-				console.log(err);
-				alert('이미 사용된 ID 입니다!');
-				setIdDuple(false);
-			}
+	const submitId = async (e) => {
+		e.preventDefault();
+		const { username } = getValues();
+		try {
+			await instance.get(`/api/users/email/${username}`);
+			alert('사용 가능한 ID 입니다!');
+			setIdDuple(true);
+		} catch (err) {
+			alert('이미 사용된 ID 입니다!');
+			setIdDuple(false);
 		}
 	};
 
-	const submitNickName = async () => {
-		if (nicknamecheck === null) {
-			alert('닉네임을 입력해주세요!');
-		} else if (nicknamecheck === false) {
-			alert('닉네임 형식을 확인해주세요!');
-		} else {
-			try {
-				await instance.get(`/api/users/nickname/${nickname_ref.current.value}`);
-				alert('사용 가능한 닉네임 입니다!');
-				setNickNameDuple(true);
-			} catch (err) {
-				console.log(err);
-				alert('이미 사용된 닉네임 입니다!');
-				setNickNameDuple(false);
-			}
+	const submitNickName = async (e) => {
+		e.preventDefault();
+		const { nickname } = getValues();
+		try {
+			await instance.get(`/api/users/nickname/${nickname}`);
+			alert('사용 가능한 닉네임 입니다!');
+			setNickNameDuple(true);
+		} catch (err) {
+			alert('이미 사용된 닉네임 입니다!');
+			setNickNameDuple(false);
 		}
 	};
 
-	const submitSignup = async () => {
-		//input 값에 공란이 있으면 알럿 띄우기
-		if (email_ref.current.value === '') {
-			alert('아이디를 입력하세요!');
-		} else if (nickname_ref.current.value === '') {
-			alert('닉네임을 입력하세요!');
-		} else if (pw_ref.current.value === '') {
-			alert('비밀번호를 입력하세요!');
-		} else if (pwcheck_ref.current.value === '') {
-			alert('비밀번호를 다시 입력하세요!');
-		} else if (userType === null) {
-			alert('유저 타입을 선택해주세요!');
-		} else if (idduple === null) {
+	const onSubmitSignup = async (data) => {
+		if (!idduple) {
 			alert('아이디 확인이 필요해요!');
-		} else if (nicknameduple === null) {
+			return;
+		} else if (!nicknameduple) {
 			alert('닉네임 확인이 필요해요!');
+			return;
 		}
-
-		if (emailcheck && nicknamecheck && pwcheck && pwrecheck && userType && idduple && nicknameduple) {
-			const user_data = {
-				username: email_ref.current.value,
-				nickname: nickname_ref.current.value,
-				password: pw_ref.current.value,
-				checkPassword: pwcheck_ref.current.value,
-				user_type: userType
-			};
-
-			try {
-				await instance.post('/api/signup', user_data);
-				alert('회원가입이 완료되었습니다!');
-				navigate('/login');
-			} catch (err) {
-				console.log(err);
-				alert('회원가입에 문제가 생겼어요!');
-			}
+		try {
+			await instance.post('/api/signup', JSON.stringify(data), {
+				headers: { 'Content-Type': `application/json` }
+			});
+			alert('회원가입이 완료되었습니다!');
+			navigate('/login');
+		} catch (err) {
+			alert('회원가입에 문제가 생겼어요!');
 		}
 	};
 
@@ -165,79 +74,104 @@ const Signup = () => {
 				<link rel="icon" type="image/png" sizes="32x32" href="32.ico" />
 				<link rel="icon" type="image/png" sizes="16x16" href="16.ico" />
 			</Helmet>
-			<SingupContent>
+			<SingupContent onSubmit={handleSubmit(onSubmitSignup)}>
 				<p>아이디</p>
 				<IdBox>
 					<>
-						<input placeholder="이메일 형식" ref={email_ref} onChange={idCheck} />
+						<input
+							placeholder="이메일 형식"
+							name="username"
+							{...register('username', {
+								required: '이메일 입력은 필수입니다.',
+								pattern: {
+									value: /\S+@\S+\.\S+/,
+									message: '이메일 형식에 맞지 않습니다.'
+								}
+							})}
+						/>
 						<button
-							className={emailcheck === null ? 'btnstart' : emailcheck ? '' : 'btnfalse'}
-							disabled={emailcheck ? false : true}
+							className={!errors.username ? 'btnstart' : 'btnfalse'}
+							disabled={errors.username ? true : false}
 							onClick={submitId}
 						>
 							{' '}
 							중복 확인
 						</button>
 					</>
-					{emailcheck === null ? (
-						<None />
-					) : emailcheck ? (
-						<None />
-					) : (
-						<Fail>
-							<p>이메일 형식으로 작성해주세요!</p>
-						</Fail>
-					)}
+					{errors.username && <Fail role="alert">{errors.username.message}</Fail>}
 				</IdBox>
 
 				<p>비밀번호</p>
 				<PwBox>
-					<input type="password" placeholder="영문/숫자 8-20자, 특수문자(!@#$%^&.*)포함 " ref={pw_ref} onChange={pwCheck} />
-					{pwcheck === null ? (
-						<None />
-					) : pwcheck ? (
-						<None />
-					) : (
-						<Fail>
-							<p>특수문자를 포함 영문/숫자(8-20자)으로 작성해주세요!</p>
-						</Fail>
-					)}
-					<input type="password" placeholder="비밀번호 확인" ref={pwcheck_ref} onChange={pwReCheck} />
-					{pwrecheck === null ? (
-						<None />
-					) : pwrecheck ? (
-						<None />
-					) : (
-						<Fail>
-							<p>입력하신 비밀번호와 다릅니다!</p>
-						</Fail>
-					)}
+					<input
+						type="password"
+						placeholder="영문/숫자 8-20자, 특수문자(!@#$%^&.*)포함 "
+						{...register('password', {
+							required: '비밀번호 입력은 필수입니다.',
+							pattern: {
+								value: /(?=.*[@$!%*?&])[0-9a-zA-Z!@#$%^&.*]$/,
+								message: '특수문자를 포함 영문/숫자(8-20자)으로 작성해주세요!'
+							},
+							minLength: {
+								value: 8,
+								message: '8자리 이상 20자리 미만으로 입력해주세요.'
+							},
+							maxLength: {
+								value: 20,
+								message: '8자리 이상 20자리 미만으로 입력해주세요.'
+							}
+						})}
+					/>
+					{errors.password && <Fail role="alert">{errors.password.message}</Fail>}
+					<input
+						type="password"
+						placeholder="비밀번호 확인"
+						{...register('checkPassword', {
+							require: '비밀번호를 확인해주세요.',
+							validate: {
+								matchesPreviousPassword: (value) => {
+									const { password } = getValues();
+									return password === value || '비밀번호가 일치하지 않습니다.';
+								}
+							}
+						})}
+					/>
+					{errors.checkPassword && <Fail role="alert">{errors.checkPassword.message}</Fail>}
 				</PwBox>
 
 				<p>닉네임</p>
 				<NicknameBox>
-					<input placeholder="한글/영문/숫자, 2-10자리 이하" ref={nickname_ref} onChange={nickNameCheck} />
+					<input
+						placeholder="한글/영문/숫자, 2-10자리 이하"
+						{...register('nickname', {
+							required: '닉네임을 입력해주세요.',
+							pattern: {
+								value: /^[a-zA-Z0-9ㄱ-ㅎ가-힣]{2,10}$/,
+								message: '2자리 이상 10자리 이하 한글/영문/숫자가 필요합니다.'
+							},
+							minLength: {
+								value: 2,
+								message: '2자리 이상 10자리 이하로 입력해주세요.'
+							},
+							maxLength: {
+								value: 10,
+								message: '2자리 이상 10자리 이하로 입력해주세요.'
+							}
+						})}
+					/>
 					<button
-						className={nicknamecheck === null ? 'btnstart' : nicknamecheck ? '' : 'btnfalse'}
-						disabled={nicknamecheck ? false : true}
+						className={!errors.nickname ? 'btnstart' : !errors.nickname ? '' : 'btnfalse'}
+						disabled={errors.nickname ? true : false}
 						onClick={submitNickName}
 					>
 						{' '}
 						중복 확인
 					</button>
 				</NicknameBox>
-				{nicknamecheck === null ? (
-					<None />
-				) : nicknamecheck ? (
-					<None />
-				) : (
-					<Fail>
-						<p>2-10자리 한글/영문/숫자를 입력해주세요!</p>
-					</Fail>
-				)}
+				{errors.nickname && <Fail role="alert">{errors.nickname.message}</Fail>}
 
 				<UsertypeBox>
-					<select name="userType" onChange={selectUserType}>
+					<select name="userType" onChange={selectUserType} {...register('user_type')}>
 						<option value="SEEKER">취준생</option>
 						<option value="JUNIOR">주니어</option>
 						<option value="SENIOR">시니어</option>
@@ -245,7 +179,7 @@ const Signup = () => {
 				</UsertypeBox>
 
 				<SignupBottom>
-					<button className={idduple && nicknameduple ? '' : 'btnfalse'} type="submit" onClick={submitSignup}>
+					<button className={(idduple && nicknameduple) || 'btnfalse'} type="submit" disabled={isSubmitting}>
 						가입하기
 					</button>
 					<Link to="/login">
@@ -281,7 +215,7 @@ const SignupWrapper = styled.div`
 	}
 `;
 
-const SingupContent = styled.div`
+const SingupContent = styled.form`
 	margin-left: auto;
 	margin-right: auto;
 	p {
@@ -409,15 +343,9 @@ const SignupBottom = styled.div`
 	}
 `;
 
-const None = styled.div`
-	display: none;
-`;
-
 const Fail = styled.div`
-	p {
-		margin-top: 2px;
-		font-size: 13px;
-		padding-left: 10px;
-		color: red;
-	}
+	color: red;
+	margin-top: 2px;
+	font-size: 13px;
+	padding-left: 10px;
 `;

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -77,27 +77,25 @@ const Signup = () => {
 			<SingupContent onSubmit={handleSubmit(onSubmitSignup)}>
 				<p>아이디</p>
 				<IdBox>
-					<>
-						<input
-							placeholder="이메일 형식"
-							name="username"
-							{...register('username', {
-								required: '이메일 입력은 필수입니다.',
-								pattern: {
-									value: /\S+@\S+\.\S+/,
-									message: '이메일 형식에 맞지 않습니다.'
-								}
-							})}
-						/>
-						<button
-							className={!errors.username ? 'btnstart' : 'btnfalse'}
-							disabled={errors.username ? true : false}
-							onClick={submitId}
-						>
-							{' '}
-							중복 확인
-						</button>
-					</>
+					<input
+						placeholder="이메일 형식"
+						name="username"
+						{...register('username', {
+							required: '이메일 입력은 필수입니다.',
+							pattern: {
+								value: /\S+@\S+\.\S+/,
+								message: '이메일 형식에 맞지 않습니다.'
+							}
+						})}
+					/>
+					<button
+						className={!errors.username ? 'btnstart' : 'btnfalse'}
+						disabled={errors.username ? true : false}
+						onClick={submitId}
+					>
+						{' '}
+						중복 확인
+					</button>
 					{errors.username && <Fail role="alert">{errors.username.message}</Fail>}
 				</IdBox>
 

--- a/src/shared/axios.js
+++ b/src/shared/axios.js
@@ -50,8 +50,8 @@ instance.interceptors.response.use(
 				sessionStorage.removeItem('Authorization');
 				window.location.href = '/login';
 			}
-			return Promise.reject(err);
 		}
+		return Promise.reject(err);
 	}
 );
 


### PR DESCRIPTION
## 해결한 이슈

- #4
- #5

<br />

## 해결 방법
### 📌 react-hook-form #4
- Login.jsx, Signup.jsx, MyInfoManage.jsx, MyPwManage.jsx
- react-hook-form 도입
- 불필요한 validation 함수 및 로직 삭제
- 불필요한 state, ref 삭제

```jsx
<input
  type="password"
  placeholder="비밀번호 확인"
  autoComplete="off"
  {...register('confirmChangePassword', {
	  required: '비밀번호가 일치하지 않습니다.',
	  validate: {
		  matchesPreviousPassword: (value) => {
			const { changePassword } = getValues();
			return changePassword === value || '비밀번호가 일치하지 않습니다.';
		  }
	  },
	  onChange: formChangeCheck
  })}
  ></input>
  {errors.confirmChangePassword && <Fail>{errors.confirmChangePassword.message}</Fail>}
```

위와 같이 react-hook-form을 사용하여 validation을 수행하고, 에러 메세지도 react-hook-form에서 관리할 수 있어
validation 결과를 나타내는 boolean 값의 state도 거의 대부분 제거할 수 있었으며 패턴 규칙 검증, 글자 수 검증 등
함수로 수행하던 검증 기능을 삭제하여 코드를 간소화 

<br />

## 캡처 첨부
![image](https://user-images.githubusercontent.com/78852661/212275876-161d555e-8b4e-41cc-be40-d3d5ca7f8788.png)



<br />

## 추가적인 태스크

### 📌 axios interceptors 수정 #5
- __axios를 통한 요청이 에러가 발생하여 reject 되어도 try-catch문에서 catch로 넘어가지 않는 현상 수정__

src/shared/axios.js에서 axios interceptors를 사용하여 기존 access token이 만료(401 에러)되었다면 응답을 가로채어 refresh token을 통해 새로운 access token으로 대체하고 기존의 요청을 수행하도록 하는 부분이 있는데, access token의 만료 문제가 아니라 다른 문제로 에러가 발생했다면 원래 들어온 에러를  `return Promise.reject(err)` 하도록 하는 의도로 구현 했었으나,
401에러일 때를 판별하는 if문에 `return Promise.reject(err)`가 들어가 있어서 401에러가 아닐 때는 응답을 가로채고 아무런 동작도 하지 않아 에러가 발생해도 에러로 취급되지 않고 try-catch에서 catch로 넘어가지 않음.

`return Promise.reject(err)`의 위치를 수정하여 401에러가 아닐 때 제대로 프로미스가 reject 되도록 하여 해결

```jsx
instance.interceptors.response.use(
	(res) => {
		return res;
	},
	async (err) => {
		if (err.response && err.response.status === 401) {
			const refreshToken = sessionStorage.getItem('Refresh__Token');
			const prevAccessToken = sessionStorage.getItem('Authorization');
			const originRequest = err.config; // 원래의 요청
			try {
				const res = await axios.put(
					`${process.env.REACT_APP_API_URL}/api/refreshToken`,
					{},
					{
						headers: {
							Authorization: prevAccessToken,
							RefreshToken: refreshToken
						}
					}
				);
				const newAccessToken = res.headers.authorization;
				sessionStorage.setItem('Authorization', newAccessToken);
				originRequest.headers.Authorization = newAccessToken;

				return instance.request(originRequest).catch((err) => {
					alert('세션이 만료되었습니다.');
					console.log(err);
					window.location.href = '/login';
				});
			} catch (err) {
				alert('세션이 만료되었습니다.');
				sessionStorage.removeItem('Authorization');
				window.location.href = '/login';
			}
		}
		return Promise.reject(err);
	}
);
```

### 📌 router/index.jsx의 privateRoutePath의 id 수정

privateRoutePath 배열에서 담고있는 객체의 id가 2부터 시작하던 것을 1부터 시작하도록 변경



<br />
<br />
