### PR TITLE
404 error 핸들링

### DIFF
--- a/src/shared/axios.ts
+++ b/src/shared/axios.ts
@@ -50,6 +50,9 @@ instance.interceptors.response.use(
 				sessionStorage.removeItem('Authorization');
 				window.location.href = '/login';
 			}
+		} else if (err.response && err.response.status === 404) {
+			alert('연결이 원활하지 않습니다. 잠시 후 다시 실행해주세요!');
+			return;
 		}
 		return Promise.reject(err);
 	}


### PR DESCRIPTION
### 404 에러 핸들링
* 404에러일 때, alert에 가공되지 않은 에러 메세지가 노출 되는 등의 문제
* axios interceptors에서 응답을 가로 채어 에러 코드가 404일 경우, 별도의 메세지를 alert를 통해 알려주고, 바로 return하여 더 이상의 로직 진행을 막아 해결
* 404 에러를 전역적이고 별도로 관리